### PR TITLE
refactor: extract model schemas from table manager

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -71,7 +71,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 5.14.0
+    version: 5.14.1
 
   promise:
     git: https://github.com/spider-gazelle/promise.git

--- a/shard.lock
+++ b/shard.lock
@@ -67,7 +67,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 5.12.2
+    version: 5.13.0
 
   promise:
     git: https://github.com/spider-gazelle/promise.git

--- a/shard.lock
+++ b/shard.lock
@@ -21,6 +21,10 @@ shards:
     git: https://github.com/spider-gazelle/bindata.git
     version: 1.9.1
 
+  crystal-kcov:
+    git: https://github.com/vici37/crystal-kcov.git
+    version: 0.1.0+git.commit.6c2191d080e01a49106b483cf0c4a0145e3f9090
+
   db:
     git: https://github.com/crystal-lang/crystal-db.git
     version: 0.10.1
@@ -67,7 +71,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 5.13.0
+    version: 5.14.0
 
   promise:
     git: https://github.com/spider-gazelle/promise.git

--- a/shard.yml
+++ b/shard.yml
@@ -56,3 +56,7 @@ development_dependencies:
   ameba:
     github: crystal-ameba/ameba
     version: ">= 0.14"
+
+  crystal-kcov:
+    github: Vici37/crystal-kcov
+    branch: master

--- a/spec/elastic_spec.cr
+++ b/spec/elastic_spec.cr
@@ -206,7 +206,10 @@ module SearchIngest
       describe ".create_document" do
         it "saves a document" do
           Elastic.bulk = bulk
+
           index = Programmer.table_name
+
+          TableManager.new.create_index(Programmer) rescue nil
 
           model = Programmer.new(name: "tenderlove")
           model.id = RethinkORM::IdGenerator.next(model)

--- a/spec/helper.cr
+++ b/spec/helper.cr
@@ -6,7 +6,7 @@ require "retriable"
 # Application config
 require "./spec_config"
 
-require "../src/search-ingest/*"
+require "../src/search-ingest"
 require "../src/api"
 
 # Helper methods for testing controllers (curl, with_server, context)
@@ -20,6 +20,7 @@ end
 
 Spec.before_suite do
   ::Log.setup "*", :debug, PlaceOS::LogBackend.log_backend
+  SearchIngest.wait_for_elasticsearch
   cleanup
 end
 

--- a/spec/schemas_spec.cr
+++ b/spec/schemas_spec.cr
@@ -1,0 +1,84 @@
+require "./helper"
+
+module SearchIngest
+  describe Schemas do
+    describe "#parents" do
+      it "finds parent relations of a model" do
+        schemas = Schemas.new
+        parents = schemas.parents(Migraine)
+        parents.should eq [{
+          name:         Schemas.document_name(Programmer),
+          index:        Programmer.table_name,
+          routing_attr: :programmer_id,
+        }]
+      end
+    end
+
+    describe "#children" do
+      it "finds the child relations of a model" do
+        schemas = Schemas.new
+        children = schemas.children(Programmer)
+        children.should eq [
+          Schemas.document_name(Beverage::Coffee),
+          Schemas.document_name(Migraine),
+        ]
+      end
+    end
+
+    describe "#index_schema" do
+      it "generates a schema for a model" do
+        schemas = Schemas.new([Broke])
+        schema = schemas.index_schema(Broke)
+        schema.should be_a(String)
+
+        # Check that the path to a field mapping exists
+        json = JSON.parse(schema)
+        json.dig?("mappings", "properties", "_document_type").should_not be_nil
+      end
+    end
+
+    describe "#properties" do
+      it "creates a mapping of table attributes to es types" do
+        schemas = Schemas.new([Broke])
+        mappings = schemas.properties(Broke).sort_by &.name
+        mappings.should eq ([
+          Schemas::TYPE_FIELD,
+          Schemas::Field.new("breaks", "text", ["keyword"]),
+          Schemas::Field.new("hasho", "object"),
+          Schemas::Field.new("id", "keyword"),
+          Schemas::Field.new("status", "boolean"),
+        ])
+      end
+
+      it "allows specification of field type" do
+        # RayGun ip attribute has an 'es_type' tag
+        schemas = Schemas.new([RayGun])
+        mappings = schemas.properties["RayGun"].sort_by &.name
+        mappings.should eq ([
+          Schemas::TYPE_FIELD,
+          Schemas::Field.new("barrel_length", "float"),
+          Schemas::Field.new("id", "keyword"),
+          Schemas::Field.new("ip", "ip"),
+          Schemas::Field.new("laser_colour", "text"),
+          Schemas::Field.new("last_shot", "date"),
+          Schemas::Field.new("rounds", "integer"),
+        ])
+      end
+
+      it "collects properties for a model with associations" do
+        schemas = Schemas.new
+        children = schemas.children(Programmer)
+        mappings = schemas.collect_index_properties(Programmer, children).sort_by &.name
+        mappings.should eq [
+          Schemas::TYPE_FIELD,
+          Schemas::Field.new("created_at", "date"),
+          Schemas::Field.new("duration", "date"),
+          Schemas::Field.new("id", "keyword"),
+          Schemas::Field.new("name", "text"),
+          Schemas::Field.new("programmer_id", "keyword"),
+          Schemas::Field.new("temperature", "integer"),
+        ]
+      end
+    end
+  end
+end

--- a/spec/schemas_spec.cr
+++ b/spec/schemas_spec.cr
@@ -2,6 +2,13 @@ require "./helper"
 
 module SearchIngest
   describe Schemas do
+    describe ".equivalent_schema?" do
+      it "does not fail on malformed schemas" do
+        broken_schema = {error: "malformed"}.to_json
+        Schemas.equivalent_schema?(broken_schema, broken_schema).should be_false
+      end
+    end
+
     describe "#parents" do
       it "finds parent relations of a model" do
         schemas = Schemas.new

--- a/spec/table_manager_spec.cr
+++ b/spec/table_manager_spec.cr
@@ -34,14 +34,17 @@ module SearchIngest
         Elastic.client &.put("/#{index}", Elastic.headers, body: wrong_schema)
         get_schema.call["mappings"].should eq wrong_schema["mappings"]
 
-        schemas = Schemas.new([Broke])
+        tm = TableManager.new([Broke], backfill: false, watch: false)
+        schemas = tm.schema_data
         schema = JSON.parse(schemas.index_schema(Broke))
+
         updated_schema = JSON.parse(get_schema.call)
 
         # Check if updated schema applied
         updated_schema.should_not eq JSON.parse(wrong_schema)
 
         updated_schema["mappings"].should eq schema["mappings"]
+
         updated_schema.dig("settings", "index", "analysis").as_h.rehash.should eq schema.dig("settings", "analysis").as_h.rehash
       end
     end

--- a/spec/table_manager_spec.cr
+++ b/spec/table_manager_spec.cr
@@ -35,10 +35,7 @@ module SearchIngest
         get_schema.call["mappings"].should eq wrong_schema["mappings"]
 
         schemas = Schemas.new([Broke])
-
-        document_name = Schemas.document_name(Broke)
-
-        schema = JSON.parse(schemas.index_schema(document_name))
+        schema = JSON.parse(schemas.index_schema(Broke))
         updated_schema = JSON.parse(get_schema.call)
 
         # Check if updated schema applied

--- a/src/search-ingest.cr
+++ b/src/search-ingest.cr
@@ -2,3 +2,19 @@ require "log_helper"
 
 require "./constants"
 require "./search-ingest/*"
+
+module SearchIngest
+  def self.wait_for_elasticsearch
+    Retriable.retry(
+      max_elapsed_time: 1.minutes,
+      on_retry: ->(_e : Exception, n : Int32, _t : Time::Span, _i : Time::Span) {
+        Log.warn { "attempt #{n} connecting to #{SearchIngest::Elastic.settings.host}:#{SearchIngest::Elastic.settings.port}" }
+      }
+    ) do
+      # Ensure elastic is available
+      raise "retry" unless SearchIngest::Elastic.healthy?
+    end
+  rescue
+    abort("Failed to connect to Elasticsearch on #{SearchIngest::Elastic.settings.host}:#{SearchIngest::Elastic.settings.port}")
+  end
+end

--- a/src/search-ingest/elastic.cr
+++ b/src/search-ingest/elastic.cr
@@ -131,54 +131,6 @@ module SearchIngest
     # Mapping
     #############################################################################################
 
-    # Traverse schemas and test equality
-    #
-    # ameba:disable Metrics/CyclomaticComplexity
-    def self.equivalent_schema?(existing_schema : String?, proposed_schema : String?) : Bool
-      return false unless existing_schema && proposed_schema
-
-      begin
-        proposed = Schema.extract(proposed_schema)
-        existing = Schema.extract(existing_schema)
-      rescue e : JSON::SerializableError
-        Log.warn(exception: e) { "malformed schema: #{proposed_schema}" }
-        return false
-      end
-
-      (existing.keys.sort! == proposed.keys.sort!) && existing.all? do |prop, mapping|
-        if prop == "join"
-          existing_relations = mapping["relations"]?.try &.as_h?
-          proposed_relations = proposed[prop]["relations"]?.try &.as_h?
-
-          existing_relations && proposed_relations && (existing_relations.keys.sort! == proposed_relations.keys.sort!) && existing_relations.all? do |k, v|
-            # Relations can be an array of join names, or a single join name
-            l = v.as_a?.try(&.map(&.as_s)) || v
-            r = proposed_relations[k]?.try &.as_a?.try(&.map(&.as_s)) || proposed_relations[k]?
-            if l.is_a? Array && r.is_a? Array
-              l.sort == r.sort
-            else
-              l == r
-            end
-          end
-        else
-          proposed[prop]? == mapping
-        end
-      end
-    end
-
-    # Model for extracting the schema of an index
-    #
-    private struct Schema
-      include JSON::Serializable
-
-      @[JSON::Field(root: "properties")]
-      getter mappings : Hash(String, JSON::Any)
-
-      def self.extract(json) : Hash(String, JSON::Any)
-        from_json(json).mappings
-      end
-    end
-
     # Get the mapping applied to an index
     def self.get_mapping?(index) : String?
       response = client &.get("/#{index}")

--- a/src/search-ingest/elastic.cr
+++ b/src/search-ingest/elastic.cr
@@ -498,7 +498,12 @@ module SearchIngest
         body = ClusterHealth.from_json(response.body)
 
         # Cluster is functional in yellow -> green states
-        body.status > ClusterHealth::Status::Red
+        case body.status
+        in .yellow?, .green? then true
+        in .red?
+          Log.warn { "cluster is up, but unhealthy" }
+          false
+        end
       else
         Log.warn { "health request failed: #{response.body}" }
         false
@@ -545,7 +550,7 @@ module SearchIngest
 
       getter task_max_waiting_in_queue_millis : Int32
 
-      getter active_shards_percent_as_number : Int32
+      getter active_shards_percent_as_number : Float32
     end
 
     # Remove documents from indices

--- a/src/search-ingest/schemas.cr
+++ b/src/search-ingest/schemas.cr
@@ -228,8 +228,8 @@ module SearchIngest
         # Ignore self
         next if name == document_name
         # Do any of the attributes define a parent relationship with current model?
-        is_child = metadata.attributes.any? do |_, meta|
-          !!meta.tags[:parent]?.try(&.==(document_name))
+        is_child = metadata.attributes.any? do |_, field|
+          !!field.tags[:parent]?.try(&.==(document_name))
         end
         name if is_child
       end

--- a/src/search-ingest/schemas.cr
+++ b/src/search-ingest/schemas.cr
@@ -1,0 +1,335 @@
+module SearchIngest
+  class Schemas
+    # Map class name to model properties
+    getter properties : Hash(String, Array(Field))
+
+    # Map from class name to schema
+    getter index_schemas : Hash(String, String)
+
+    # Class names of managed tables
+    getter models : Array(String)
+
+    def initialize(models : Array(Class) = MANAGED_TABLES)
+      @models = models.map { |m| self.class.document_name(m) }
+      @properties = generate_properties(models)
+      @index_schemas = generate_schemas(models)
+    end
+
+    # Strips the namespace from the model
+    def self.document_name(model)
+      name = model.is_a?(Class) ? model.name : model
+      name.split("::").last
+    end
+
+    # Look up model schema by class
+    def index_schema(model : Class | String) : String
+      index_schemas[self.class.document_name(model)]
+    end
+
+    # Look up index name by class
+    def index_name(model) : String
+      MODEL_METADATA[self.class.document_name(model)].table_name
+    end
+
+    # Schema Generation
+    #############################################################################################
+
+    # Generate a map of models to schemas
+    def generate_schemas(models)
+      schemas = {} of String => String
+      models.each do |model|
+        name = self.class.document_name(model)
+        schemas[name] = construct_document_schema(name)
+      end
+      schemas
+    end
+
+    private INDEX_SETTINGS = {
+      analysis: {
+        analyzer: {
+          default: {
+            tokenizer: "standard",
+            filter:    ["lowercase", "preserved_ascii_folding"],
+          },
+        },
+        filter: {
+          preserved_ascii_folding: {
+            type:              "asciifolding",
+            preserve_original: true,
+          },
+        },
+      },
+    }
+
+    # Generate the index type mapping structure
+    def construct_document_schema(model) : String
+      name = self.class.document_name(model)
+      children = children(name)
+      properties = collect_index_properties(name, children)
+
+      # Generate property mapping
+      property_mapping = properties.map { |field| {field.name, field.field_mapping} }.to_h
+
+      # Only include join if model has children
+      property_mapping = property_mapping.merge(join_field(name, children)) unless children.empty?
+
+      {
+        settings: INDEX_SETTINGS,
+        mappings: {
+          properties: property_mapping,
+        },
+      }.to_json
+    end
+
+    # Property Generation
+    #############################################################################################
+
+    def validate_tag(tag)
+      return unless tag.is_a? String
+      if valid_es_type?(tag)
+        tag
+      else
+        Log.warn { "invalid tag `#{tag}` encountered" }
+        nil
+      end
+    end
+
+    # Now that we are generating joins on the parent_id, we need to specify if we are generating
+    # a child or a single document
+    # Maps from crystal types to Elasticsearch field datatypes
+    def generate_index_properties(model, child = false) : Array(Field)
+      document_name = self.class.document_name(model)
+
+      properties = MODEL_METADATA[document_name].attributes.compact_map do |field, options|
+        ::Log.with_context do
+          Log.context.set(model: document_name, field: field)
+
+          type_tag = validate_tag(options.tags[:es_type]?)
+          subfield = validate_tag(options.tags[:es_subfield]?).try { |v| [v] }
+
+          field_type = type_tag || klass_to_es_type(options.klass)
+
+          Field.new(field.to_s, field_type, subfield) unless field_type.nil?
+        end
+      end
+
+      properties << TYPE_FIELD
+    end
+
+    # Collects all properties relevant to an index and collapse them into a schema
+    def collect_index_properties(
+      model : String | Class,
+      children : Array(String)? = nil
+    ) : Array(Field)
+      name = self.class.document_name(model)
+      if !children || children.empty?
+        properties[model]
+      else
+        index_models = children.dup << name
+        # Get the properties of all relevent tables
+        properties.select(index_models).values.flatten.uniq!
+      end
+    end
+
+    # Construct properties for given models
+    def generate_properties(models)
+      models.each_with_object({} of String => Array(Field)) do |model, props|
+        name = self.class.document_name(model)
+        props[name] = generate_index_properties(name)
+      end
+    end
+
+    # Generate join fields for parent relations
+    def join_field(model, children)
+      relations = children.size == 1 ? children.first : children.sort
+      {
+        :join => {
+          type:      "join",
+          relations: {
+            # Use types for defining the parent-child relation
+            model => relations,
+          },
+        },
+      }
+    end
+
+    # Allows several document types beneath a single index
+    TYPE_FIELD = Field.new("_document_type", "keyword")
+
+    # Valid elasticsearch field datatypes
+    private ES_TYPES = {
+      # String
+      "text", "keyword",
+      # Numeric
+      "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float",
+      # Other
+      "boolean", "date", "binary", "object",
+      # Special
+      "ip", "completion",
+      # Spacial
+      "geo_point", "geo_shape",
+    }
+
+    # Determine if type tag is a valid Elasticsearch field datatype
+    private def valid_es_type?(es_type : String)
+      es_type.in? ES_TYPES
+    end
+
+    private ES_MAPPINGS = {
+      "Bool":    "boolean",
+      "Float32": "float",
+      "Float64": "double",
+      "Int16":   "short",
+      "Int32":   "integer",
+      "Int64":   "long",
+      "Int8":    "byte",
+      "String":  "text",
+      "Time":    "date",
+    }
+
+    # Map from a class type to an es type
+    private def klass_to_es_type(klass_name) : String | Nil
+      if klass_name.starts_with?("Array")
+        collection_type(klass_name, "Array")
+      elsif klass_name.starts_with?("Set")
+        collection_type(klass_name, "Set")
+      elsif klass_name == "JSON::Any" || klass_name.starts_with?("Hash") || klass_name.starts_with?("NamedTuple")
+        "object"
+      else
+        ES_MAPPINGS[klass_name]?.tap do |es_type|
+          Log.warn { "no ES mapping for #{klass_name}" } if es_type.nil?
+        end
+      end
+    end
+
+    # Collections allowed as long as they are homogeneous
+    private def collection_type(klass_name : String, collection_type : String)
+      klass_to_es_type(klass_name.lchop("#{collection_type}(").rstrip(')'))
+    end
+
+    # Relations
+    #############################################################################################
+
+    # Find name and ES routing of document's parents
+    def parents(model : Class | String) : Array(Parent)
+      document_name = self.class.document_name(model)
+      MODEL_METADATA[document_name].attributes.compact_map do |field, options|
+        parent_name = options.tags[:parent]?
+        unless parent_name.nil?
+          {
+            name:         parent_name,
+            index:        index_name(parent_name),
+            routing_attr: field,
+          }
+        end
+      end
+    end
+
+    # Get names of all children associated with model
+    def children(model : Class | String)
+      document_name = self.class.document_name(model)
+      MODEL_METADATA.compact_map do |name, metadata|
+        # Ignore self
+        next if name == document_name
+        # Do any of the attributes define a parent relationship with current model?
+        is_child = metadata.attributes.any? do |_, meta|
+          !!meta.tags[:parent]?.try(&.==(document_name))
+        end
+        name if is_child
+      end
+    end
+
+    # Accessors for data via class (or class name)
+    ###############################################################################################
+
+    def properties(klass : Class | String)
+      properties[self.class.document_name(klass)]
+    end
+
+    def index_schemas(klass : Class | String)
+      index_schemas[self.class.document_name(klass)]
+    end
+
+    # Data structs
+    ###############################################################################################
+
+    record Field, name : String, type : String, fields : Array(String)? = nil do
+      def_equals name, type, fields
+
+      # Represents the mapping of this field in an Elasticsearch schema
+      def field_mapping
+        if (field_mappings = fields)
+          {
+            "type"   => type,
+            "fields" => field_mappings.map { |subtype| {subtype, {type: subtype}} }.to_h,
+          }
+        else
+          {"type" => type}
+        end
+      end
+    end
+
+    private record(Metadata,
+      table_name : String,
+      attributes : Hash(Symbol, Options),
+    ) do
+      record(Options,
+        klass : String,
+        tags : Hash(Symbol, String),
+      ) do
+        # Extract required options from active-model attribute options
+        def self.from_active_model(options)
+          case tags = options[:tags]?.try &.to_h
+          when Hash(NoReturn, NoReturn), Nil
+            tags = {} of Symbol => String
+          else
+            tags = tags.each_with_object({} of Symbol => String) do |(k, v), object|
+              case v
+              when String then object[k] = v
+              when Symbol then object[k] = v.to_s
+              end
+            end
+          end
+          new(options[:klass], tags)
+        end
+      end
+    end
+
+    # Metadata extraction from `active-model` classes
+    ###############################################################################################
+
+    macro finished
+      # All RethinkORM models with abstract and empty classes removed
+      # :nodoc:
+      MODELS = {} of Nil => Nil
+      __create_model_metadata
+    end
+
+    macro __create_model_metadata
+      {% for model, fields in RethinkORM::Base::FIELD_MAPPINGS %}
+        {% unless model.abstract? || fields.empty? %}
+          {% if MANAGED_TABLES.map(&.resolve).includes?(model) %}
+            {% MODELS[model] = fields %}
+          {% end %}
+        {% end %}
+      {% end %}
+
+      # Extracted metadata from ORM classes
+      MODEL_METADATA = {
+        {% for klass, fields in MODELS %}
+          {{ klass.stringify.split("::").last }} => Metadata.new(
+              attributes: {
+              {% for attr, options in fields %}
+                {% options[:klass] = options[:klass].resolve if options[:klass].is_a?(Path) %}
+                {% options[:klass] = options[:klass].union_types.reject(&.nilable?).first if !options[:klass].is_a?(StringLiteral) && options[:klass].union? %}
+                {% options[:klass] = options[:klass].stringify unless options[:klass].is_a?(StringLiteral) %}
+                {{ attr.symbolize }} => Metadata::Options.from_active_model({{ options }}),
+              {% end %}
+              },
+              table_name: {{ klass.id }}.table_name,
+            ),
+        {% end %}
+      } {% if MODELS.empty? %} of Nil => Nil {% end %}
+    end
+  end
+end

--- a/src/search-ingest/schemas.cr
+++ b/src/search-ingest/schemas.cr
@@ -94,7 +94,7 @@ module SearchIngest
       (existing.keys.sort! == proposed.keys.sort!) && existing.all? do |prop, mapping|
         if prop == "join"
           existing_relations = mapping["relations"]?.try &.as_h?
-          proposed_relations = proposed[prop]["relations"]?.try &.as_h?
+          proposed_relations = proposed[prop]?.try(&.["relations"]?.try(&.as_h?))
 
           existing_relations && proposed_relations && (existing_relations.keys.sort! == proposed_relations.keys.sort!) && existing_relations.all? do |k, v|
             # Relations can be an array of join names, or a single join name

--- a/src/search-ingest/table_manager.cr
+++ b/src/search-ingest/table_manager.cr
@@ -186,7 +186,7 @@ module SearchIngest
       Elastic.delete_index(index)
 
       # Apply current mapping
-      create_index(index)
+      create_index(model)
 
       true
     rescue e
@@ -326,7 +326,7 @@ module SearchIngest
       proposed = schema_data.index_schema(model)
       existing = Elastic.get_mapping?(schema_data.index_name(model))
 
-      equivalent = Elastic.equivalent_schema?(existing, proposed)
+      equivalent = Schemas.equivalent_schema?(existing, proposed)
       Log.warn { {model: model.to_s, proposed: proposed, existing: existing, message: "index mapping conflict"} } unless equivalent
 
       !equivalent

--- a/src/search-ingest/table_manager.cr
+++ b/src/search-ingest/table_manager.cr
@@ -6,152 +6,51 @@ require "retriable"
 
 require "./elastic"
 require "./types"
+require "./schemas"
 
 # Class to manage rethinkdb models sync with elasticsearch
 module SearchIngest
   class TableManager
     Log = ::Log.for(self)
 
-    record Field, name : String, type : String, fields : Array(String)? = nil do
-      def_equals name, type, fields
-
-      # Represents the mapping of this field in an Elasticsearch schema
-      def field_mapping
-        if (field_mappings = fields)
-          {
-            "type"   => type,
-            "fields" => field_mappings.map { |subtype| {subtype, {type: subtype}} }.to_h,
-          }
-        else
-          {"type" => type}
-        end
-      end
-    end
-
-    # Map class name to model properties
-    getter properties : Hash(String, Array(Field)) = {} of String => Array(Field)
-
-    # Map from class name to schema
-    getter index_schemas : Hash(String, String) = {} of String => String
-
-    # Class names of managed tables
-    getter models : Array(String) = [] of String
-
-    private getter coordination : Channel(Nil) = Channel(Nil).new
-
     macro finished
-      # All RethinkORM models with abstract and empty classes removed
-      # :nodoc:
-      MODELS = {} of Nil => Nil
-      __create_model_metadata
       __generate_methods([:changes, :all])
     end
 
-    private record(Metadata,
-      table_name : String,
-      attributes : Hash(Symbol, Options),
-    ) do
-      record(Options,
-        klass : String,
-        tags : Hash(Symbol, String),
-      ) do
-        # Extract required options from active-model attribute options
-        def self.from_active_model(options)
-          case tags = options[:tags]?.try &.to_h
-          when Hash(NoReturn, NoReturn), Nil
-            tags = {} of Symbol => String
-          else
-            tags = tags.each_with_object({} of Symbol => String) do |(k, v), object|
-              case v
-              when String then object[k] = v
-              when Symbol then object[k] = v.to_s
-              end
-            end
-          end
-          new(options[:klass], tags)
-        end
-      end
-    end
-
-    macro __create_model_metadata
-      {% for model, fields in RethinkORM::Base::FIELD_MAPPINGS %}
-        {% unless model.abstract? || fields.empty? %}
-          {% if MANAGED_TABLES.map(&.resolve).includes?(model) %}
-            {% MODELS[model] = fields %}
-          {% end %}
-        {% end %}
-      {% end %}
-
-      # Extracted metadata from ORM classes
-      MODEL_METADATA = {
-        {% for klass, fields in MODELS %}
-          {{ klass.stringify.split("::").last }} => Metadata.new(
-              attributes: {
-              {% for attr, options in fields %}
-                {% options[:klass] = options[:klass].resolve if options[:klass].is_a?(Path) %}
-                {% options[:klass] = options[:klass].union_types.reject(&.nilable?).first if !options[:klass].is_a?(StringLiteral) && options[:klass].union? %}
-                {% options[:klass] = options[:klass].stringify unless options[:klass].is_a?(StringLiteral) %}
-                {{ attr.symbolize }} => Metadata::Options.from_active_model({{ options }}),
-              {% end %}
-              },
-              table_name: {{ klass.id }}.table_name,
-            ),
-        {% end %}
-      } {% if MODELS.empty? %} of Nil => Nil {% end %}
-    end
-
-    # TODO: Move away from String backed stores, use Class
-
     macro __generate_methods(methods)
       {% for method in methods %}
-        __generate_method({{ method }})
-      {% end %}
-    end
-
-    macro __generate_method(method)
-      # Dispatcher for {{ method.id }}
-      def {{ method.id }}(model)
-        document_name = TableManager.document_name(model)
-        # Generate {{ method.id }} method calls
-        case document_name
-        {% for klass in MODELS.keys %}
-        when {{ klass.stringify.split("::").last }}
-          {{ klass.id }}.{{ method.id }}(runopts: {"read_mode" => "majority"})
-        {% end %}
-        else
-          raise "No #{ {{ method.stringify }} } for '#{model}'"
+        # Dispatcher for {{ method.id }}
+        def {{ method.id }}(model)
+          Log.trace { "{{ method }} for #{model}" }
+          # Generate {{ method.id }} method calls
+          case SearchIngest::Schemas.document_name(model)
+          {% for klass in SearchIngest::Schemas::MODELS.keys %}
+          when SearchIngest::Schemas.document_name({{ klass.id }})
+            {{ klass.id }}.{{ method.id }}(runopts: {"read_mode" => "majority"})
+          {% end %}
+          else
+            raise "No #{ {{ method.stringify }} } for '#{model}'"
+          end
         end
-      end
-    end
-
-    # Look up model schema by class
-    def index_schema(model : Class | String) : String
-      document_name = TableManager.document_name(model)
-      index_schemas[TableManager.document_name(model)]
-    end
-
-    # Look up index name by class
-    def index_name(model) : String
-      MODEL_METADATA[TableManager.document_name(model)].table_name
+      {% end %}
     end
 
     # Initialisation
     #############################################################################################
 
+    # Metadata related to elasticsearch extracted from `active-model` classes
+    getter schema_data : Schemas
+
+    delegate models, to: schema_data
+
     def initialize(
-      klasses : Array(Class) = MANAGED_TABLES,
+      models = MANAGED_TABLES,
       backfill : Bool = false,
       watch : Bool = false
     )
       Log.debug { {bulk_api: Elastic.bulk?, backfill: backfill, watch: watch, message: "starting TableManager"} }
 
-      @models = klasses.map { |klass| TableManager.document_name(klass) }
-
-      # Collate model properties
-      @properties = generate_properties(models)
-
-      # Generate schemas
-      @index_schemas = generate_schemas(models)
+      @schema_data = Schemas.new(models)
 
       # Initialise indices to a consistent state
       initialise_indices(backfill)
@@ -280,9 +179,7 @@ module SearchIngest
     # Clear, update mapping an ES index and refill with rethinkdb documents
     def reindex(model : String | Class) : Bool
       Log.info { {method: "reindex", model: model.to_s} }
-      name = TableManager.document_name(model)
-
-      index = index_name(name)
+      index = schema_data.index_name(model)
       # Delete index
       Elastic.delete_index(index)
       # Apply current mapping
@@ -297,6 +194,8 @@ module SearchIngest
 
     # Watch
     #############################################################################################
+
+    private getter coordination : Channel(Nil) = Channel(Nil).new
 
     delegate close, to: coordination
 
@@ -314,7 +213,7 @@ module SearchIngest
       end
     end
 
-    def watch_table(model : String | Class)
+    def watch_table(model)
       changefeed = nil
       spawn do
         coordination.receive?
@@ -330,8 +229,7 @@ module SearchIngest
       ) do
         begin
           return if stopped?(model)
-          changefeed = changes(TableManager.document_name(model))
-          Log.info { {method: "changes", model: model.to_s} }
+          changefeed = changes(model)
           changefeed.not_nil!.each do |change|
             return if stopped?(model)
             spawn do
@@ -348,10 +246,9 @@ module SearchIngest
     end
 
     private def process_event(model, change)
-      name = TableManager.document_name(model)
-      index = index_name(name)
-      parents = parents(name)
-      no_children = children(name).empty?
+      index = schema_data.index_name(model)
+      parents = schema_data.parents(model)
+      no_children = schema_data.children(model).empty?
 
       event, document = change.event, change.value
       Log.debug { {method: "process_event", event: event.to_s.downcase, model: model.to_s, document_id: document.id, parents: parents} }
@@ -387,7 +284,7 @@ module SearchIngest
 
     private def stopped?(model)
       coordination.closed?.tap do |closed|
-        Log.debug { {message: "unwatching table", table: model.to_s} } if closed
+        Log.debug { {message: "unwatching table", model: model.to_s} } if closed
       end
     end
 
@@ -406,8 +303,8 @@ module SearchIngest
     # Applies a schema to an index in elasticsearch
     #
     def create_index(model : String | Class)
-      index = index_name(model)
-      mapping = index_schema(model)
+      index = schema_data.index_name(model)
+      mapping = schema_data.index_schema(model)
 
       Elastic.apply_index_mapping(index, mapping)
     end
@@ -416,15 +313,15 @@ module SearchIngest
     #
     def consistent_indices?
       models.all? do |model|
-        Elastic.check_index?(index_name(model)) && !mapping_conflict?(model)
+        Elastic.check_index?(schema_data.index_name(model)) && !mapping_conflict?(model)
       end
     end
 
     # Diff the current mapping schema (if any) against provided mapping schema
     #
     def mapping_conflict?(model)
-      proposed = index_schema(model)
-      existing = Elastic.get_mapping?(index_name(model))
+      proposed = schema_data.index_schema(model)
+      existing = Elastic.get_mapping?(schema_data.index_name(model))
 
       equivalent = Elastic.equivalent_schema?(existing, proposed)
       Log.warn { {model: model.to_s, proposed: proposed, existing: existing, message: "index mapping conflict"} } unless equivalent
@@ -432,235 +329,11 @@ module SearchIngest
       !equivalent
     end
 
-    # Schema Generation
-    #############################################################################################
-
-    # Generate a map of models to schemas
-    def generate_schemas(models)
-      schemas = {} of String => String
-      models.each do |model|
-        name = TableManager.document_name(model)
-        schemas[name] = construct_document_schema(name)
-      end
-      schemas
-    end
-
-    private INDEX_SETTINGS = {
-      analysis: {
-        analyzer: {
-          default: {
-            tokenizer: "whitespace",
-            filter:    ["lowercase", "preserved_ascii_folding"],
-          },
-        },
-        filter: {
-          preserved_ascii_folding: {
-            type:              "asciifolding",
-            preserve_original: true,
-          },
-        },
-      },
-    }
-
-    # Generate the index type mapping structure
-    def construct_document_schema(model) : String
-      name = TableManager.document_name(model)
-      children = children(name)
-      properties = collect_index_properties(name, children)
-
-      # Generate property mapping
-      property_mapping = properties.map { |field| {field.name, field.field_mapping} }.to_h
-
-      # Only include join if model has children
-      property_mapping = property_mapping.merge(join_field(name, children)) unless children.empty?
-
-      {
-        settings: INDEX_SETTINGS,
-        mappings: {
-          properties: property_mapping,
-        },
-      }.to_json
-    end
-
-    # Property Generation
-    #############################################################################################
-
-    def validate_tag(tag)
-      return unless tag.is_a? String
-      if valid_es_type?(tag)
-        tag
-      else
-        Log.warn { "invalid tag `#{tag}` encountered" }
-        nil
-      end
-    end
-
-    # Now that we are generating joins on the parent_id, we need to specify if we are generating
-    # a child or a single document
-    # Maps from crystal types to Elasticsearch field datatypes
-    def generate_index_properties(model, child = false) : Array(Field)
-      document_name = TableManager.document_name(model)
-
-      properties = MODEL_METADATA[document_name].attributes.compact_map do |field, options|
-        ::Log.with_context do
-          Log.context.set(model: model, field: field)
-
-          type_tag = validate_tag(options.tags[:es_type]?)
-          subfield = validate_tag(options.tags[:es_subfield]?).try { |v| [v] }
-
-          field_type = type_tag || klass_to_es_type(options.klass)
-
-          Field.new(field.to_s, field_type, subfield) unless field_type.nil?
-        end
-      end
-
-      properties << TYPE_FIELD
-    end
-
-    # Collects all properties relevant to an index and collapse them into a schema
-    def collect_index_properties(
-      model : String | Class,
-      children : Array(String)? = nil
-    ) : Array(Field)
-      name = TableManager.document_name(model)
-      if !children || children.empty?
-        properties[model]
-      else
-        index_models = children.dup << name
-        # Get the properties of all relevent tables
-        properties.select(index_models).values.flatten.uniq!
-      end
-    end
-
-    # Construct properties for given models
-    def generate_properties(models)
-      models.each_with_object({} of String => Array(Field)) do |model, props|
-        name = TableManager.document_name(model)
-        props[name] = generate_index_properties(name)
-      end
-    end
-
-    # Generate join fields for parent relations
-    def join_field(model, children)
-      relations = children.size == 1 ? children.first : children.sort
-      {
-        :join => {
-          type:      "join",
-          relations: {
-            # Use types for defining the parent-child relation
-            model => relations,
-          },
-        },
-      }
-    end
-
-    # Allows several document types beneath a single index
-    TYPE_FIELD = Field.new("_document_type", "keyword")
-
-    # Valid elasticsearch field datatypes
-    private ES_TYPES = {
-      # String
-      "text", "keyword",
-      # Numeric
-      "long", "integer", "short", "byte", "double", "float", "half_float", "scaled_float",
-      # Other
-      "boolean", "date", "binary", "object",
-      # Special
-      "ip", "completion",
-      # Spacial
-      "geo_point", "geo_shape",
-    }
-
-    # Determine if type tag is a valid Elasticsearch field datatype
-    private def valid_es_type?(es_type : String)
-      es_type.in? ES_TYPES
-    end
-
-    private ES_MAPPINGS = {
-      "Bool":    "boolean",
-      "Float32": "float",
-      "Float64": "double",
-      "Int16":   "short",
-      "Int32":   "integer",
-      "Int64":   "long",
-      "Int8":    "byte",
-      "String":  "text",
-      "Time":    "date",
-    }
-
-    # Map from a class type to an es type
-    private def klass_to_es_type(klass_name) : String | Nil
-      if klass_name.starts_with?("Array")
-        collection_type(klass_name, "Array")
-      elsif klass_name.starts_with?("Set")
-        collection_type(klass_name, "Set")
-      elsif klass_name == "JSON::Any" || klass_name.starts_with?("Hash") || klass_name.starts_with?("NamedTuple")
-        "object"
-      else
-        ES_MAPPINGS[klass_name]?.tap do |es_type|
-          Log.warn { "no ES mapping for #{klass_name}" } if es_type.nil?
-        end
-      end
-    end
-
-    # Collections allowed as long as they are homogeneous
-    private def collection_type(klass_name : String, collection_type : String)
-      klass_to_es_type(klass_name.lchop("#{collection_type}(").rstrip(')'))
-    end
-
-    # Relations
-    #############################################################################################
-
-    # Find name and ES routing of document's parents
-    def parents(model : Class | String) : Array(Parent)
-      document_name = TableManager.document_name(model)
-      MODEL_METADATA[document_name].attributes.compact_map do |field, options|
-        parent_name = options.tags[:parent]?
-        unless parent_name.nil?
-          {
-            name:         parent_name,
-            index:        index_name(parent_name),
-            routing_attr: field,
-          }
-        end
-      end
-    end
-
-    # Get names of all children associated with model
-    def children(model : Class | String)
-      document_name = TableManager.document_name(model)
-      MODEL_METADATA.compact_map do |name, metadata|
-        # Ignore self
-        next if name == document_name
-        # Do any of the attributes define a parent relationship with current model?
-        is_child = metadata.attributes.any? do |_, metadata|
-          !!metadata.tags[:parent]?.try(&.==(document_name))
-        end
-        name if is_child
-      end
-    end
-
-    # Property accessors via class
-
-    def properties(klass : Class | String)
-      properties[TableManager.document_name(klass)]
-    end
-
-    def index_schemas(klass : Class | String)
-      index_schemas[TableManager.document_name(klass)]
-    end
-
     # Utils
     #############################################################################################
 
     def cancel!
       raise Error.new("TableManager cancelled")
-    end
-
-    # Strips the namespace from the model
-    def self.document_name(model : Class | String)
-      model = model.name unless model.is_a? String
-      model.split("::").last
     end
   end
 end


### PR DESCRIPTION
Extracts elasticsearch index schema generation from `TableManager` into `Schemas`.
This separates _some_ concerns, and seems like a good place to draw a boundary.

Next step in the refactor is to use a `PlaceOS::Resource(T)` for each monitored table, i.e. #20 