### PR TITLE
chore(shard.lock): bump dependencies

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   action-controller:
     git: https://github.com/spider-gazelle/action-controller.git
-    version: 5.5.3
+    version: 5.6.2
 
   active-model:
     git: https://github.com/spider-gazelle/active-model.git
@@ -14,7 +14,7 @@ shards:
 
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.3.1
+    version: 1.4.2
 
   backtracer:
     git: https://github.com/sija/backtracer.cr.git
@@ -102,7 +102,7 @@ shards:
 
   openssl_ext:
     git: https://github.com/spider-gazelle/openssl_ext.git
-    version: 2.2.1
+    version: 2.3.0
 
   opentelemetry-api:
     git: https://github.com/wyhaines/opentelemetry-api.cr.git
@@ -130,7 +130,7 @@ shards:
 
   placeos-models:
     git: https://github.com/placeos/models.git
-    version: 8.13.1
+    version: 8.13.3
 
   placeos-resource:
     git: https://github.com/place-labs/resource.git


### PR DESCRIPTION
for recent model changes to be reflected in the schema