### PR TITLE
feat: add service loading route for k8s

### DIFF
--- a/spec/table_manager_spec.cr
+++ b/spec/table_manager_spec.cr
@@ -31,7 +31,8 @@ module SearchIngest
         Elastic.client &.put("/#{index}", Elastic.headers, body: wrong_schema)
         get_schema.call["mappings"].should eq wrong_schema["mappings"]
 
-        TableManager.new(tables, backfill: false, watch: false)
+        manager = TableManager.new(tables, backfill: false, watch: false)
+        manager.load_success?.should be_true
 
         schema = JSON.parse(schemas.index_schema(Broke))
 

--- a/src/api.cr
+++ b/src/api.cr
@@ -55,6 +55,21 @@ module SearchIngest
 
     class_property? failed_healthcheck : Bool = false
 
+    # has the service finished loading
+    @[AC::Route::GET("/ready")]
+    def ready : Nil
+      raise Error::NotReady.new("startup has not completed") unless self.class.table_manager.load_complete?
+    end
+
+    class Error < Exception
+      class NotReady < Error
+      end
+    end
+
+    @[AC::Route::Exception(Error::NotReady, status_code: HTTP::Status::SERVICE_UNAVAILABLE)]
+    def not_ready_error(_error) : Nil
+    end
+
     # health check
     @[AC::Route::GET("/")]
     def index : Nil

--- a/src/app.cr
+++ b/src/app.cr
@@ -186,7 +186,13 @@ else
   Log.info { "Mirroring #{SearchIngest::MANAGED_TABLES.map(&.name).sort!.join(", ")}" }
 
   # Start API's TableManager instance
-  SearchIngest::Api.table_manager
+  manager = SearchIngest::Api.table_manager
+  spawn do
+    if !manager.load_success?
+      Log.fatal(exception: manager.load_error) { "failed to index resources" }
+      server.close
+    end
+  end
 
   # Start the server
   server.run do

--- a/src/search-ingest/elastic.cr
+++ b/src/search-ingest/elastic.cr
@@ -49,12 +49,12 @@ module SearchIngest
     # Yield an acquired client from the pool
     #
     def self.client(&)
-      pool = (@@pool ||= DB::Pool(Elastic).new(
+      pool = (@@pool ||= DB::Pool(Elastic).new(DB::Pool::Options.new(
         initial_pool_size: settings.pool_size // 4,
         max_pool_size: settings.pool_size,
         max_idle_pool_size: settings.idle_pool_size,
         checkout_timeout: settings.pool_timeout
-      ) { Elastic.new }).as(DB::Pool(Elastic))
+      )) { Elastic.new }).as(DB::Pool(Elastic))
 
       pool.retry do
         client = pool.checkout


### PR DESCRIPTION
prevents service termination on startup where there are a lot of database entries to index